### PR TITLE
Adding toggle for audio focus

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,6 +147,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:$support_libraries_version"
     implementation "androidx.legacy:legacy-support-v4:$support_libraries_version"
     implementation "androidx.preference:preference:$support_libraries_version"
+    implementation "androidx.media:media:1.2.0"
     implementation 'io.sentry:sentry-android:1.7.21'
 
     implementation "androidx.lifecycle:lifecycle-extensions:$architecture_components_version"

--- a/app/src/main/java/org/mozilla/focus/gecko/AudioFocusSessionDelegate.kt
+++ b/app/src/main/java/org/mozilla/focus/gecko/AudioFocusSessionDelegate.kt
@@ -1,0 +1,95 @@
+package org.mozilla.focus.gecko
+
+import android.content.Context
+import android.media.AudioManager
+import androidx.media.AudioAttributesCompat
+import androidx.media.AudioFocusRequestCompat
+import androidx.media.AudioManagerCompat
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.MediaSession
+import java.lang.ref.WeakReference
+
+class AudioFocusSessionDelegate(context: Context): MediaSession.Delegate, AudioManager.OnAudioFocusChangeListener {
+
+  var shouldAllowAudioFocus = false
+
+  private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+  private var weakSession: WeakReference<MediaSession?> = WeakReference(null)
+
+  private var mediaSession: MediaSession?
+    get() = weakSession.get()?.takeIf { it.isActive }
+    set(value) {
+      weakSession = WeakReference(value)
+    }
+
+  private var resumeOnFocusGain = false
+  private var playbackDelayed = false
+
+  private val focusRequest by lazy {
+    val attributes = AudioAttributesCompat.Builder()
+      .setUsage(AudioAttributesCompat.USAGE_MEDIA)
+      .setContentType(AudioAttributesCompat.CONTENT_TYPE_MUSIC)
+      .build()
+
+    AudioFocusRequestCompat.Builder(AudioManagerCompat.AUDIOFOCUS_GAIN)
+      .setAudioAttributes(attributes)
+      .setOnAudioFocusChangeListener(this)
+      .setWillPauseWhenDucked(false)
+      .build()
+  }
+
+  private fun pause(temporary: Boolean = false) {
+    resumeOnFocusGain = temporary
+    mediaSession?.pause()
+  }
+
+  private fun play(delayed: Boolean = false) {
+    playbackDelayed = delayed
+    if (delayed) {
+      // pause for now and play when focus change tells we are good to go
+      pause()
+    } else {
+      mediaSession?.play()
+    }
+  }
+
+  private fun reset() {
+    resumeOnFocusGain = false
+    playbackDelayed = false
+  }
+
+  override fun onPlay(geckoSession: GeckoSession, mediaSession: MediaSession) {
+    if (!shouldAllowAudioFocus) return
+
+    this.mediaSession = mediaSession
+
+    synchronized(this) {
+      reset()
+      when (AudioManagerCompat.requestAudioFocus(audioManager, focusRequest)) {
+        AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> return // session is already playing -- no action needed
+        AudioManager.AUDIOFOCUS_REQUEST_DELAYED -> play(delayed = true)
+        else -> pause() // all other scenarios, stop playback for now
+      }
+    }
+  }
+
+  override fun onStop(geckoSession: GeckoSession, mediaSession: MediaSession) {
+    synchronized(this) {
+      // be a good citizen and give back the audio focus
+      AudioManagerCompat.abandonAudioFocusRequest(audioManager, focusRequest)
+      reset()
+    }
+  }
+
+  override fun onAudioFocusChange(focusChange: Int) {
+    synchronized(this) {
+      when (focusChange) {
+        AudioManager.AUDIOFOCUS_GAIN -> if (playbackDelayed || resumeOnFocusGain) play()
+        AudioManager.AUDIOFOCUS_LOSS -> pause()
+        AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
+        AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> pause(temporary = true)
+      }
+    }
+  }
+}

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -254,6 +254,7 @@ object TelemetryWrapper {
                             resources.getString(R.string.pref_key_autocomplete_preinstalled),
                             resources.getString(R.string.pref_key_autocomplete_custom),
                             resources.getString(R.string.pref_key_remote_debugging),
+                            resources.getString(R.string.pref_key_audio_focus),
                             resources.getString(R.string.pref_key_homescreen_tips),
                             resources.getString(R.string.pref_key_open_new_tab),
                             resources.getString(R.string.pref_key_show_search_suggestions),

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -51,6 +51,11 @@ class Settings private constructor(context: Context) {
                     getPreferenceKey(R.string.pref_key_remote_debugging),
                     false)
 
+    fun shouldAllowAudioFocus(): Boolean =
+            preferences.getBoolean(
+                    getPreferenceKey(R.string.pref_key_audio_focus),
+                    true)
+
     fun shouldDisplayHomescreenTips() =
             preferences.getBoolean(
                     getPreferenceKey(R.string.pref_key_homescreen_tips),

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -48,6 +48,7 @@
     <string name="pref_key_mozilla_screen" translatable="false"><xliff:g id="preference_key">pref_screen_mozilla</xliff:g></string>
     <string name="pref_key_search_screen" translatable="false"><xliff:g id="preference_key">pref_screen_search</xliff:g></string>
     <string name="pref_key_remote_debugging" translatable="false"><xliff:g id="preference_key">pref_remote_debugging</xliff:g></string>
+    <string name="pref_key_audio_focus" translatable="false"><xliff:g id="preference_key">pref_audio_focus</xliff:g></string>
 
     <string name="has_opened_new_tab" translatable="false"><xliff:g id="preference_key">has_opened_new_tab</xliff:g></string>
     <string name="has_added_to_home_screen" translatable="false"><xliff:g id="preference_key">has_added_to_home_screen</xliff:g></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -680,6 +680,12 @@ be temporary, and you can try again later.</li>
     <!-- Preference to enable remote debugging of the app via USB or Wi-Fi -->
     <string name="preference_remote_debugging">Remote debugging via USB/Wi-Fi</string>
 
+    <!-- Preference to halt media playback when other apps attempt to seize audio focus -->
+    <string name="preference_audio_focus">Request audio focus</string>
+
+    <!-- Description for the audio focus preference describing the audio focus guidelines -->
+    <string name="audio_focus_description">Play nicely with other apps competing for audio playback</string>
+
     <!-- Title for the fingerprint authentication dialog box that is shown to the user when opening the app.
      %1$s is replaced with the app name -->
     <string name="biometric_auth_title">Unlock %1$s</string>

--- a/app/src/main/res/xml/advanced_settings.xml
+++ b/app/src/main/res/xml/advanced_settings.xml
@@ -11,5 +11,11 @@
             android:key="@string/pref_key_remote_debugging"
             android:layout="@layout/focus_preference_no_icon"
             android:title="@string/preference_remote_debugging" />
+        <androidx.preference.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="@string/pref_key_audio_focus"
+            android:layout="@layout/focus_preference_no_icon"
+            android:summary="@string/audio_focus_description"
+            android:title="@string/preference_audio_focus" />
     </androidx.preference.PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This is enabled by default as most popular browsers honor audio focus.
It can still be toggled off as a user may have legitimate use cases
where they don't want playback to be interrupted by external apps.